### PR TITLE
Add Documents and Images admin, models, enums

### DIFF
--- a/app/Enums/DocumentType.php
+++ b/app/Enums/DocumentType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Enums;
+
+enum DocumentType: string
+{
+    case Planning = 'planning';
+    case Depliant = 'depliant';
+    case QstMajeurs = 'qst_majeurs';
+    case QstMineurs = 'qst_mineurs';
+    case AssuranceMaif = 'assurance_maif';
+    case AssuranceIaSports = 'assurance_ia_sports';
+    case CompteRenduAg = 'compte_rendu_ag';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Planning => 'Planning des cours',
+            self::Depliant => "Dépliant d'informations",
+            self::QstMajeurs => 'Questionnaire de santé (Majeurs)',
+            self::QstMineurs => 'Questionnaire de santé (Mineurs)',
+            self::AssuranceMaif => 'Assurance MAIF',
+            self::AssuranceIaSports => 'Assurance complémentaire IA Sports',
+            self::CompteRenduAg => 'Compte rendu AG',
+        };
+    }
+}

--- a/app/Enums/ImageType.php
+++ b/app/Enums/ImageType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum ImageType: string
+{
+    case Logo = 'logo';
+    case Banner = 'banner';
+    case Background = 'background';
+    case Tarifs = 'tarifs';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Logo => 'Logo',
+            self::Banner => 'Bannière',
+            self::Background => 'Image de fond',
+            self::Tarifs => 'Image des tarifs',
+        };
+    }
+}

--- a/app/Filament/Admin/Resources/Documents/DocumentResource.php
+++ b/app/Filament/Admin/Resources/Documents/DocumentResource.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Documents;
+
+use App\Filament\Admin\Resources\Documents\Pages\CreateDocument;
+use App\Filament\Admin\Resources\Documents\Pages\EditDocument;
+use App\Filament\Admin\Resources\Documents\Pages\ListDocuments;
+use App\Filament\Admin\Resources\Documents\Schemas\DocumentForm;
+use App\Filament\Admin\Resources\Documents\Tables\DocumentsTable;
+use App\Models\Document;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class DocumentResource extends Resource
+{
+    protected static ?string $model = Document::class;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::DocumentArrowUp;
+    protected static string | \UnitEnum | null $navigationGroup = 'Documents et liens';
+    protected static ?string $modelLabel = 'Document';
+    protected static ?string $pluralModelLabel = 'Documents';
+    protected static ?string $recordTitleAttribute = 'Document';
+    protected static ?int $navigationSort = 5;
+
+    public static function form(Schema $schema): Schema
+    {
+        return DocumentForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return DocumentsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListDocuments::route('/'),
+            'create' => CreateDocument::route('/create'),
+            'edit' => EditDocument::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Documents/Pages/CreateDocument.php
+++ b/app/Filament/Admin/Resources/Documents/Pages/CreateDocument.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Documents\Pages;
+
+use App\Filament\Admin\Resources\Documents\DocumentResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDocument extends CreateRecord
+{
+    protected static string $resource = DocumentResource::class;
+}

--- a/app/Filament/Admin/Resources/Documents/Pages/EditDocument.php
+++ b/app/Filament/Admin/Resources/Documents/Pages/EditDocument.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Documents\Pages;
+
+use App\Filament\Admin\Resources\Documents\DocumentResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDocument extends EditRecord
+{
+    protected static string $resource = DocumentResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Documents/Pages/ListDocuments.php
+++ b/app/Filament/Admin/Resources/Documents/Pages/ListDocuments.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Documents\Pages;
+
+use App\Filament\Admin\Resources\Documents\DocumentResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDocuments extends ListRecords
+{
+    protected static string $resource = DocumentResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Documents/Schemas/DocumentForm.php
+++ b/app/Filament/Admin/Resources/Documents/Schemas/DocumentForm.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Documents\Schemas;
+
+use Filament\Schemas\Schema;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
+use App\Enums\DocumentType;
+use Illuminate\Support\Facades\Storage;
+
+class DocumentForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('key')
+                ->label('Type de document')
+                ->options(collect(DocumentType::cases())->mapWithKeys(fn ($case) => [$case->value => $case->getLabel()]))
+                ->required()
+                ->unique(ignoreRecord: true)
+                ->searchable(),
+            FileUpload::make('file_path')
+                ->label('Document PDF')
+                ->disk('public')
+                ->directory('documents')
+                ->acceptedFileTypes(['application/pdf'])
+                ->preserveFilenames(false)
+                ->deleteUploadedFileUsing(function ($file) {
+                    Storage::disk('public')->delete($file);
+                }),
+        ]);
+    }
+}

--- a/app/Filament/Admin/Resources/Documents/Tables/DocumentsTable.php
+++ b/app/Filament/Admin/Resources/Documents/Tables/DocumentsTable.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Documents\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class DocumentsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('key')
+                    ->formatStateUsing(fn ($state) => $state->getLabel())
+                    ->sortable()
+                    ->label('Type'),
+                TextColumn::make('file_path')->label('Fichier'),
+                TextColumn::make('updated_at')
+                    ->dateTime('j/m/Y H:i')
+                    ->sortable()
+                    ->label('Date de modification'),
+            ])
+            ->filters([
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/Images/ImageResource.php
+++ b/app/Filament/Admin/Resources/Images/ImageResource.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Images;
+
+use App\Filament\Admin\Resources\Images\Pages\CreateImage;
+use App\Filament\Admin\Resources\Images\Pages\EditImage;
+use App\Filament\Admin\Resources\Images\Pages\ListImages;
+use App\Filament\Admin\Resources\Images\Schemas\ImageForm;
+use App\Filament\Admin\Resources\Images\Tables\ImagesTable;
+use App\Models\Image;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class ImageResource extends Resource
+{
+    protected static ?string $model = Image::class;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::Photo;
+    protected static string | \UnitEnum | null $navigationGroup = 'Documents et liens';
+    protected static ?string $modelLabel = 'Image';
+    protected static ?string $pluralModelLabel = 'Images';
+    protected static ?string $recordTitleAttribute = 'Image';
+    protected static ?int $navigationSort = 6;
+
+    public static function form(Schema $schema): Schema
+    {
+        return ImageForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return ImagesTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListImages::route('/'),
+            'create' => CreateImage::route('/create'),
+            'edit' => EditImage::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Images/Pages/CreateImage.php
+++ b/app/Filament/Admin/Resources/Images/Pages/CreateImage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Images\Pages;
+
+use App\Filament\Admin\Resources\Images\ImageResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateImage extends CreateRecord
+{
+    protected static string $resource = ImageResource::class;
+}

--- a/app/Filament/Admin/Resources/Images/Pages/EditImage.php
+++ b/app/Filament/Admin/Resources/Images/Pages/EditImage.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Images\Pages;
+
+use App\Filament\Admin\Resources\Images\ImageResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditImage extends EditRecord
+{
+    protected static string $resource = ImageResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Images/Pages/ListImages.php
+++ b/app/Filament/Admin/Resources/Images/Pages/ListImages.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Images\Pages;
+
+use App\Filament\Admin\Resources\Images\ImageResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListImages extends ListRecords
+{
+    protected static string $resource = ImageResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Images/Schemas/ImageForm.php
+++ b/app/Filament/Admin/Resources/Images/Schemas/ImageForm.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Images\Schemas;
+
+use App\Enums\ImageType;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Storage;
+
+class ImageForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('key')
+                    ->label('Type d\'image')
+                    ->options(collect(ImageType::cases())->mapWithKeys(fn ($case) => [$case->value => $case->getLabel()]))
+                    ->required()
+                    ->unique(ignoreRecord: true)
+                    ->searchable(),
+                FileUpload::make('file_path')
+                    ->label('Image')
+                    ->disk('public')
+                    ->directory('images')
+                    ->acceptedFileTypes(['image/*'])
+                    ->preserveFilenames(false)
+                    ->deleteUploadedFileUsing(function ($file) {
+                        Storage::disk('public')->delete($file);
+                    }),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/Images/Tables/ImagesTable.php
+++ b/app/Filament/Admin/Resources/Images/Tables/ImagesTable.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Images\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ImagesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('key')
+                    ->formatStateUsing(fn ($state) => $state->getLabel())
+                    ->sortable()
+                    ->badge()
+                    ->searchable()
+                    ->label('Type d\'image'),
+                TextColumn::make('file_path')
+                    ->label('Chemin du fichier'),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime('j/m/Y H:i')
+                    ->sortable()
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\Course;
+use App\Models\Document;
+use App\Models\Image;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Contracts\Foundation\Application;
@@ -29,17 +31,14 @@ class MainController extends Controller
 
     public function inscription(): View|Application|Factory
     {
-        return view('inscription');
+        $documents = Document::pluck('file_path', 'key');
+
+        return view('inscription', ['documents' => $documents]);
     }
 
     public function register(): View|Application|Factory
     {
         return view('auth.register');
-    }
-
-    public function news(): View|Application|Factory
-    {
-        return view('news');
     }
 
     public function planning(): Application|Factory|View
@@ -91,7 +90,9 @@ class MainController extends Controller
 
     public function tarifs(): View|Application|Factory
     {
-        return view('tarifs');
+        $images = Image::pluck('file_path', 'key');
+
+        return view('tarifs', ['images' => $images]);
     }
 
     public function login(): View|Factory|Application

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Enums\DocumentType;
+
+class Document extends Model
+{
+    protected $fillable = ['key', 'file_path'];
+
+    protected $casts = [
+        'key' => DocumentType::class,
+    ];
+}

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Enums\ImageType;
+
+class Image extends Model
+{
+    protected $fillable = ['key', 'file_path'];
+
+    protected $casts = [
+        'key' => ImageType::class,
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Models\Document;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Pagination\Paginator;
@@ -18,6 +19,12 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Paginator::useBootstrap();
+
+        view()->composer('partials.footer', function ($view) {
+            $documents = Document::pluck('file_path', 'key');
+
+            $view->with('documents', $documents);
+        });
 
         Event::listen(
             Registered::class,

--- a/database/migrations/2026_08_12_175625_create_documents_table.php
+++ b/database/migrations/2026_08_12_175625_create_documents_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('documents', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('file_path');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
+};

--- a/database/migrations/2026_08_13_135023_create_images_table.php
+++ b/database/migrations/2026_08_13_135023_create_images_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('images', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('file_path');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('images');
+    }
+};

--- a/resources/views/inscription.blade.php
+++ b/resources/views/inscription.blade.php
@@ -2,6 +2,10 @@
 
 @section('title', 'Inscription')
 
+@php
+use App\Enums\DocumentType;
+@endphp
+
 @section('content')
     <div class="container mt-5">
         <div class="position-relative mx-auto">
@@ -11,26 +15,32 @@
                         <strong>Inscription</strong>
                     </h1>
                     <p class="mt-2 text-muted">
-                        A partir du 1er septembre 2025 <br> <br>
+                        A partir du 1er septembre {{ date('Y') }} <br> <br>
                         Les inscriptions peuvent se faire toute l'année et uniquement via le site Helloasso. <br>
                         Le lien sera activé à partir du 1er Septembre <br>
-                        <a href="https://www.helloasso.com/associations/joie-et-gymnastique-au-val-d-yerres/adhesions/bulletin-d-inscription-2025-2026-1" target="_blank">Lien pour s'inscrire</a> <br> <br>
+                        <a href="https://www.helloasso.com/associations/joie-et-gymnastique-au-val-d-yerres/adhesions/bulletin-d-inscription-2025-2026-1" target="_blank">Lien pour s'inscrire</a>
+
+                        <br> <br>
                         Au moment de votre adhésion, vous devez lire attentivement le questionnaire de santé. <br>
                         En cas de réponse positive à une ou plusieurs questions, vous devrez nous transmettre un certificat médical de moins de 6 mois <br> <br>
                         Si vous avez répondu à toutes les questions par la négative, il n'est pas nécessaire de transmettre l'attestation à l'association.
                     </p>
-                    <p class="mt-4 text-muted text-center fs-6">
-                        Planning des cours
-                    </p>
-                    <div class="embed-responsive mx-5">
-                        <iframe id="pdfFrame2" class="embed-responsive-item w-100" src="{{ asset('assets/pdf/planning2025-2026.pdf') }}"></iframe>
-                    </div>
+                    @if(isset($documents[DocumentType::Planning->value]))
+                        <p class="mt-4 text-muted text-center fs-6">
+                            Planning des cours
+                        </p>
+                        <div class="embed-responsive mx-5">
+                            <iframe id="pdfFrame2" class="embed-responsive-item w-100" src="{{ Storage::url($documents[DocumentType::Planning->value]) }}"></iframe>
+                        </div>
+                    @endif
+                    @if(isset($documents[DocumentType::Depliant->value]))
                     <p class="mt-4 text-muted text-center fs-6">
                         Dépliant d'informations
                     </p>
                     <div class="embed-responsive mx-5">
-                        <iframe id="pdfFrame2" class="embed-responsive-item w-100" src="{{ asset('assets/pdf/depliant2025.pdf') }}"></iframe>
+                        <iframe id="pdfFrame2" class="embed-responsive-item w-100" src="{{ Storage::url($documents[DocumentType::Depliant->value]) }}"></iframe>
                     </div>
+                    @endif
 
                 </div>
             </div>

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -1,3 +1,8 @@
+@php
+    use App\Enums\DocumentType;
+    use Illuminate\Support\Facades\Storage;
+@endphp
+
 <!-- Footer -->
 <footer class="text-center border-top mt-5">
     <div class="container">
@@ -23,38 +28,63 @@
                 <div class="col">
                     <a href="{{ route('planning') }}">Le planning</a>
                 </div>
+                @if(isset($documents[DocumentType::AssuranceMaif->value]))
                 <div class="col">
-                    <a href="{{ asset('/assets/pdf/garanties-maif.pdf') }}">Assurance MAIF</a>
+                    <a href="{{ Storage::url($documents[DocumentType::AssuranceMaif->value]) }}">Assurance MAIF</a>
                 </div>
+                @else
+                <div class="col">
+                </div>
+                @endif
             </div>
             <div class="row">
                 <div class="col">
                     <a href="{{ route('inscription') }}">Nous rejoindre</a>
                 </div>
+                @if(isset($documents[DocumentType::AssuranceIaSports->value]))
                 <div class="col">
-                    <a href="{{ asset('/assets/pdf/SOUSCRIPTION-IA-SPORT.pdf') }}">Assurance complémentaire IA Sports</a>
+                    <a href="{{ Storage::url($documents[DocumentType::AssuranceIaSports->value]) }}">Assurance complémentaire IA Sports</a>
                 </div>
+                @else
+                <div class="col">
+                </div>
+                @endif
             </div>
             <div class="row">
                 <div class="col">
                 </div>
+                @if(isset($documents[DocumentType::CompteRenduAg->value]))
                 <div class="col">
-                    <a href="{{ asset('/assets/pdf/CR-AG-du-07dec2024.pdf') }}">Compte rendu AG</a>
+                    <a href="{{ Storage::url($documents[DocumentType::CompteRenduAg->value]) }}">Compte rendu AG</a>
                 </div>
+                @else
+                <div class="col">
+                </div>
+                @endif
             </div>
             <div class="row">
                 <div class="col">
                 </div>
+                @if(isset($documents[DocumentType::QstMajeurs->value]))
                 <div class="col">
-                    <a href="{{ asset('/assets/pdf/questionnaire-majeur.pdf') }}">Questionnaire de santé (Majeurs)</a>
+                    <a href="{{ Storage::url($documents[DocumentType::QstMajeurs->value]) }}">Questionnaire de santé (Majeurs)</a>
                 </div>
+                @else
+                <div class="col">
+                </div>
+                @endif
             </div>
             <div class="row">
                 <div class="col">
                 </div>
+                @if(isset($documents[DocumentType::QstMineurs->value]))
                 <div class="col">
-                    <a href="{{ asset('/assets/pdf/questionnaire-mineur.pdf') }}">Questionnaire de santé (Mineurs)</a>
+                    <a href="{{ Storage::url($documents[DocumentType::QstMineurs->value]) }}">Questionnaire de santé (Mineurs)</a>
                 </div>
+                @else
+                <div class="col">
+                </div>
+                @endif
             </div>
         </section>
 

--- a/resources/views/tarifs.blade.php
+++ b/resources/views/tarifs.blade.php
@@ -2,6 +2,10 @@
 
 @section('title', 'Tarifs')
 
+@php
+use App\Enums\ImageType;
+@endphp
+
 @section('content')
     <div class="container mt-5">
         <div class="position-relative mx-auto">
@@ -10,9 +14,11 @@
                     <h1 class="mb-4">
                         <strong>Tarifs</strong>
                     </h1>
-                    <div class="text-center">
-                        <img src="{{ asset('assets/pdf/TARIFS-2025-2026.png') }}" alt="tarifs-2025-2026" class="img-fluid">
-                    </div>
+                    @if(@isset($images[ImageType::Tarifs->value]))
+                        <div class="text-center">
+                            <img src="{{ Storage::url($images[ImageType::Tarifs->value]) }}" alt="tarifs" class="img-fluid">
+                        </div>
+                    @endif
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This pull request introduces a new admin management system for documents and images, including their types, storage, and display in the application. It adds database tables, Eloquent models, Filament admin resources, and updates to controller logic to make documents and images available in views. The changes are grouped into backend infrastructure (models, migrations, enums), admin interface (Filament resources), and frontend integration.

**Backend Infrastructure**

* Added `Document` and `Image` Eloquent models, each with a `key` (enum) and `file_path`, and cast their `key` attribute to new enums (`DocumentType`, `ImageType`).
* Created new enums `DocumentType` and `ImageType` to define allowed types and provide human-readable labels.
* Added database migrations to create `documents` and `images` tables, each with unique `key` and `file_path` columns.

**Admin Interface (Filament Resources)**

* Implemented Filament resource classes for both `Document` and `Image`, including forms for upload and type selection, tables for listing, and CRUD pages (list, create, edit, delete).

**Frontend Integration**

* Updated `MainController` methods to pass documents and images to the `inscription` and `tarifs` views, respectively, using the new models. 
* Registered a view composer in `AppServiceProvider` to make documents available in the footer partial. 