### PR TITLE
Fix date on inscription page and update animator description

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,38 +1,6 @@
 @extends('main')
 
 @section('title', 'Accueil')
-{{--
-@php
-    $animateurs = [
-        'Fabrice' => 'Danse-Move, Gym Entretien, <br>
-         Abdo-Fessiers Etirements',
-        'Isabelle' => 'LIA Aérobic, <br> Renfo spécial Jambes/Etirements',
-        'Joëlle' => 'Body Zen, Gym Entretien, <br>
-        Stretching Postural, <br> Equilibre et Coordination Séniors, <br>
-         Taille Abdo-Fessiers',
-        'Luckie' => 'Stretching Postural',
-        'Mary' => 'Yoga',
-        'Nathalie' => 'Souplesse Etirements, Body Zen, <br>
-         Gym Détente Méthodes Pilates',
-        'Rose Marie' => 'Gym Douce, Renfo Training',
-        'Vincent' => 'Gym Musculaire, Gym Tonic, <br>
-         Renforcement Musculaire',
-        'Claire' => 'Yoga Nidra',
-        'Animateur' => 'Aquagym Piscine des Sénart'
-    ];
-    $bureau = [
-        'Gabriele MAKKAOUI' => 'Présidente',
-        'Michèle FLAMEN' => 'Secrétaire',
-        'Michelle ROUSSEAU' => 'Secrétaire Adjointe',
-        'Claudine LE CHAUDELEC' => 'Trésorière',
-        'Gérard AUSSEIL' => 'Membre',
-        'Danièle CAMPION' => 'Membre',
-        'Marie-Bernadette CHORON' => 'Membre',
-        'Danielle COUVREUX' => 'Membre',
-        'Bernadette MANSOUR' => 'Membre',
-        'Françoise MOGUET' => 'Membre',
-    ];
-@endphp --}}
 
 @section('content')
     <div id="carousel" class="carousel carousel-dark slide" data-bs-ride="carousel">
@@ -184,7 +152,7 @@
                         <img src="{{ $animateur->getPhotoUrlAttribute() }}" class="rounded-circle mb-2" alt="Photo de {{ $animateur->name }}" width="150" height="150">
                         <h5>{{ $animateur->name }}</h5>
                         <p class="text-muted">
-                            {{ $animateur->courses->pluck('title')->unique()->implode(', ') }}
+                            {{ $animateur->description }}
                         </p>
                     </div>
 

--- a/resources/views/inscription.blade.php
+++ b/resources/views/inscription.blade.php
@@ -17,7 +17,7 @@ use App\Enums\DocumentType;
                     <p class="mt-2 text-muted">
                         A partir du 24 août {{ date('Y') }} <br> <br>
                         Les inscriptions peuvent se faire toute l'année et uniquement via le site Helloasso. <br>
-                        Le lien sera activé à partir du 1er Septembre <br>
+                        Le lien sera activé à partir du 24 août <br>
                         <a href="https://www.helloasso.com/associations/joie-et-gymnastique-au-val-d-yerres/adhesions/bulletin-d-inscription-2026-2027-1" target="_blank">Lien pour s'inscrire</a>
 
                         <br> <br>


### PR DESCRIPTION
This pull request makes minor updates to the display and content of the website's main and registration pages. The most notable changes include updating the registration opening date and improving how instructor information is shown.

Content and Display Updates:

* Updated the registration page to state that the Helloasso registration link will be activated starting August 24 instead of September 1.
* On the homepage, changed the instructor information display to use the `description` attribute instead of a list of course titles.

Code Cleanup:

* Removed an unused PHP block that previously defined arrays of instructors and board members in `index.blade.php`.