### PR TITLE
Fix animator description

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -152,7 +152,7 @@
                         <img src="{{ $animateur->getPhotoUrlAttribute() }}" class="rounded-circle mb-2" alt="Photo de {{ $animateur->name }}" width="150" height="150">
                         <h5>{{ $animateur->name }}</h5>
                         <p class="text-muted">
-                            {{ $animateur->description }}
+                            {!! nl2br(e($animateur->bio)) !!}
                         </p>
                     </div>
 


### PR DESCRIPTION
This pull request updates how the bio of each `animateur` is displayed on the main page. The change ensures that line breaks in the bio are preserved and that the content is properly escaped for security.

* Display improvements:
  * In `index.blade.php`, the `bio` field is now rendered with escaped HTML and line breaks using `{!! nl2br(e($animateur->bio)) !!}` instead of simply outputting `description`. This prevents XSS vulnerabilities and keeps formatting.