### PR TITLE
Fix OpenStreetMap 403r error and modal display on planning page

### DIFF
--- a/resources/views/planning.blade.php
+++ b/resources/views/planning.blade.php
@@ -169,8 +169,16 @@
     <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js'></script>
 
     <script>
+        let eventMapInstance = null;
+
         window.initMap = function(latitude, longitude) {
             const mapDiv = document.getElementById('eventMap');
+
+            if (eventMapInstance) {
+                eventMapInstance.remove();
+                eventMapInstance = null;
+            }
+
             mapDiv.innerHTML = '';
 
             if (!latitude || !longitude || isNaN(parseFloat(latitude))) {
@@ -178,14 +186,19 @@
                 return;
             }
 
-            const map = L.map('eventMap').setView([parseFloat(latitude), parseFloat(longitude)], 15);
+            eventMapInstance = L.map('eventMap').setView([parseFloat(latitude), parseFloat(longitude)], 15);
 
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 maxZoom: 19,
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            }).addTo(map);
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+                referrerPolicy: 'strict-origin-when-cross-origin'
+            }).addTo(eventMapInstance);
 
-            L.marker([parseFloat(latitude), parseFloat(longitude)]).addTo(map);
+            L.marker([parseFloat(latitude), parseFloat(longitude)]).addTo(eventMapInstance);
+
+            setTimeout(() => {
+                eventMapInstance.invalidateSize();
+            }, 100);
         };
 
         document.addEventListener('DOMContentLoaded', function() {
@@ -254,8 +267,10 @@
                             }
                             $('#eventModal .modal-animator').html(animatorHtml);
                             $('#eventModal .modal-location').text("Lieu : " + event.location);
-                            initMap(event.latitude, event.longitude);
+
+                            // 4. On affiche le modal AVANT d'initialiser la carte
                             $('#eventModal').modal('show');
+                            initMap(event.latitude, event.longitude);
                         }
                     });
 
@@ -268,4 +283,3 @@
         });
     </script>
 @endsection
-


### PR DESCRIPTION
This pull request improves the handling and display of the event map in the `planning.blade.php` view, focusing on fixing map rendering issues and ensuring the map is properly initialized each time the event modal is opened.

**Improvements to map initialization and rendering:**

* Added an `eventMapInstance` variable to track the map instance, ensuring any existing map is removed before a new one is created to prevent rendering issues when reopening the modal.
* Moved the call to `initMap` after showing the event modal, ensuring the map container is visible and sized correctly when the map is initialized.
* Added a call to `invalidateSize()` on the map instance after initialization to fix display issues that can occur when the map is rendered in a hidden container.

**Enhancements to map configuration:**

* Set a stricter `referrerPolicy` for the OpenStreetMap tile layer for improved security.
* Minor cleanup: removed unnecessary blank line at the end of the script.